### PR TITLE
Added "Nix Italia" NUG

### DIFF
--- a/lists/NUGs/italy/default.nix
+++ b/lists/NUGs/italy/default.nix
@@ -1,0 +1,8 @@
+{
+  keywords = "online";
+  name = "Nix Italia";
+  subtitle =  "No strict schedule";
+  tag = "Italy";
+  target = "_blank";
+  url = "https://matrix.to/#/#it:nixos.org";
+}


### PR DESCRIPTION
Before accepting (hopefully :upside_down_face:) this we would like to know if it's possible having a notion page like [liverpool.nix.ug](liverpool.nix.ug)

In that case I would change the `url` to that page.