### PR TITLE
add leipzig.nix | Nix User Group #6 

### DIFF
--- a/lists/NUGs/leipzig/default.nix
+++ b/lists/NUGs/leipzig/default.nix
@@ -1,0 +1,8 @@
+{
+  keywords = "First Meetup";
+  name = "leipzig.nix | Nix User Group";
+  subtitle = "Was machen wir heute? Nix!";
+  tag = "Germany";
+  target = "_blank";
+  url = "https://leipzig-nix.github.io/";
+}


### PR DESCRIPTION
Supercedes https://github.com/nix-how/nix.ug/pull/6