### PR TITLE
NUGs: add Stuttgart

### DIFF
--- a/lists/NUGs/stuttgart/default.nix
+++ b/lists/NUGs/stuttgart/default.nix
@@ -1,0 +1,8 @@
+{
+  keywords = "offline in-person stuttgart germany";
+  name = "Stuttgart NixOS Meetup";
+  subtitle =  "Every second Tuesday at alternating locations";
+  tag = "Germany";
+  target = "_blank";
+  url = "https://matrix.to/#/#nixos-stuttgart:matrix.org";
+}


### PR DESCRIPTION
Adding our monthly NixOS Meetup in Stuttgart/Germany.