### PR TITLE
fix spelling and link of nürnberg ug

### DIFF
--- a/lists/NUGs/nürnberg/default.nix
+++ b/lists/NUGs/nürnberg/default.nix
@@ -1,8 +1,8 @@
 {
   keywords = "offline in-person nürnberg germany";
   name = "Nürnberg NixOS Meetup";
-  subtitle =  "Every third Tuesday at Nerdberg E.v.";
+  subtitle =  "Every third Tuesday at Nerdberg e.V.";
   tag = "Germany";
   target = "_blank";
-  url = "https://matrix.to/#/#nixos-nuernberg:nerdberg.de";
+  url = "https://matrix.to/#/#nixos-nuernberg:matrix.org";
 }


### PR DESCRIPTION
Sorry for the trouble, I was able to join with the old url, but multiple people reported problems with the nerdberg.de domain so I changed it to matrix.org. Also fixed the spelling of e.V. 
