### PR TITLE
events: update map to set default snowflake

### DIFF
--- a/lists/Events/default.nix
+++ b/lists/Events/default.nix
@@ -11,5 +11,5 @@ let
 in
 {
   inherit name;
-  items = map (n: (import n) // { logo = if ((find ".+logo\.+" n) == []) then "snowflake" else "assets/${baseNameOf n}/${baseNameOf (toString (map toString (find ".+logo\.+" n)))}"; } ) moduleFolderPaths;
+  items = map (n: (import n) // rec { icon = if logo == "" then "fas fa-snowflake" else ""; logo = if ((find ".+logo\.+" n) == []) then "" else "assets/${baseNameOf n}/${baseNameOf (toString (map toString (find ".+logo\.+" n)))}"; } ) moduleFolderPaths;
 }


### PR DESCRIPTION
## Description

Noticed this after a recent PR: https://github.com/nix-how/nix.ug/pull/48

Change mirrors the way the map is generated for NUGs so that the events that dont have a logo arent broken images on the site.

NixCon NA broken on https://nix.ug:
![ss-202401191705708263](https://github.com/nix-how/nix.ug/assets/30531572/d68c6053-f131-4114-82d6-26e8bcb77861)

NixCon NA correctly defaulting to snowflake:
![ss-202401191705708283](https://github.com/nix-how/nix.ug/assets/30531572/85a97ee2-a627-4f2d-ad98-5eefe11d77a3)

## Tests

Running locally generated default logo as expected for NixCon NA
```
nix run .#serve
```
