### PR TITLE
updated nix hamburg ug url

### DIFF
--- a/lists/NUGs/hamburg/default.nix
+++ b/lists/NUGs/hamburg/default.nix
@@ -5,5 +5,5 @@
   keywords = "offline hamburg germany";
   tag = "Germany";
   target = "_blank";
-  url = "https://nix-hh.de/";
+  url = "https://nix-hamburg.de/";
 }


### PR DESCRIPTION
This pull request addresses an issue with the outdated URL for the Nix Hamburg user group. The current URL in the project was no longer valid, and I've updated it to the new, correct URL.

## Changes Made

Updated the Nix Hamburg user group URL in the relevant source files.
Verified the correctness of the new URL by visiting the updated link.

## Testing

I have tested the updated URL to ensure it now directs users to the correct Nix Hamburg user group page. The link is functional, and users should have no issues accessing the group's information.

## Additional Notes

Please review and merge this pull request at your earliest convenience.
If there are any questions or concerns regarding this update, please feel free to reach out.

Thank you for your attention to this matter.