### PR TITLE
Add "Nix in Finland"

### DIFF
--- a/lists/NUGs/finland/default.nix
+++ b/lists/NUGs/finland/default.nix
@@ -7,5 +7,5 @@
   '';
   tag = "Finland";
   target = "_blank";
-  url = "https://nix-fi.github.io/";
+  url = "https://fi.nix.ug";
 }

--- a/lists/NUGs/finland/default.nix
+++ b/lists/NUGs/finland/default.nix
@@ -1,0 +1,11 @@
+{
+  keywords = "offline in-person helsinki finland löyly";
+  name = "Nix in Finland";
+  subtitle = ''
+    Office hours in Helsinki and occasional visits to other cities in Finland.
+    No fixed schedule (yet).
+  '';
+  tag = "Finland";
+  target = "_blank";
+  url = "https://nix-fi.github.io/";
+}


### PR DESCRIPTION
Adds NUG Finland (we've so far only met in Helsinki, but I anticipate it'd only make sense for potential volunteers in other cities to reuse the domain)

@MatthewCroughan it is my understanding that it's also possible to set-up a redirect or a CNAME from something like `fi.nix.ug`, instead of advertising the github pages directly?

CC @xhalo32