### PR TITLE
planet-nix: yearly conference

### DIFF
--- a/lists/Events/nixcon-na/default.nix
+++ b/lists/Events/nixcon-na/default.nix
@@ -1,8 +1,0 @@
-{
-  keywords = "";
-  name = "NixCon NA";
-  subtitle = "Yearly, North America";
-  tag = "North America";
-  target = "_blank";
-  url = "https://2024-na.nixcon.org/";
-}

--- a/lists/Events/planet-nix/default.nix
+++ b/lists/Events/planet-nix/default.nix
@@ -1,0 +1,8 @@
+{
+  keywords = "";
+  name = "Planet Nix";
+  subtitle = "Yearly, North America";
+  tag = "North America";
+  target = "_blank";
+  url = "https://planetnix.com/";
+}


### PR DESCRIPTION
## Description

nixcon-na should be removed from the list since all efforts are now going into the `Planet Nix` conference.

It’s going to be in Pasadena, California on March 6th-7th in the same location as last year’s NixCon US.
It'll be co-located at [Scale 22x](https://www.socallinuxexpo.org/scale/22x)

site: https://planetnix.com/
discourse announcement: https://discourse.nixos.org/t/announcing-planet-nix/55350
