### PR TITLE
Update Dresden homepage and name

### DIFF
--- a/lists/NUGs/dresden/default.nix
+++ b/lists/NUGs/dresden/default.nix
@@ -1,8 +1,8 @@
 {
   keywords = "Meetup";
-  name = "nix-meetup | Dresden";
+  name = "nix-meetup Dresden";
   subtitle = "about once a month";
   tag = "Germany";
   target = "_blank";
-  url = "https://c3d2.de/nix-meetup.html";
+  url = "https://nix-meetup.c3d2.de/about";
 }


### PR DESCRIPTION
The old URL is a redirect to the new one.