### PR TITLE
NUGs/brussels: update link

### DIFF
--- a/lists/NUGs/brussels/default.nix
+++ b/lists/NUGs/brussels/default.nix
@@ -1,8 +1,8 @@
 {
   keywords = "offline in-person";
   name = "Brussels Nix User Group | BruNix";
-  subtitle =  "Every second Monday of the month 18:00 - 21:00 CET at BeCentral";
+  subtitle = "Every second Monday of the month 18:00 - 21:00 CET at BeCentral";
   tag = "Belgium";
   target = "_blank";
-  url = "https://brunix.glitch.me/";
+  url = "https://www.benix.be/";
 }


### PR DESCRIPTION
@hoh made a new website for the BruNix NUG (https://github.com/benix-be/www.benix.be), hereby updating the link on nix.ug