### PR TITLE
Update URL for London Nix User Group

### DIFF
--- a/lists/NUGs/london/default.nix
+++ b/lists/NUGs/london/default.nix
@@ -3,5 +3,5 @@
   name = "London Nix User Group";
   subtitle =  "About once every two months";
   tag = "United Kingdom";
-  url = "https://www.eventbrite.co.uk/e/london-nix-user-group-tickets-729795787847";
+  url = "https://discourse.nixos.org/t/london-nix-user-group/27825";
 }


### PR DESCRIPTION
Update the URL as Eventbrite is no longer used.