### PR TITLE
events.nixcon: use toplevel domain instead of year

### DIFF
--- a/lists/Conferences/nixcon/default.nix
+++ b/lists/Conferences/nixcon/default.nix
@@ -4,5 +4,5 @@
   subtitle = "Yearly, Europe";
   tag = "Europe";
   target = "_blank";
-  url = "https://2023.nixcon.org/";
+  url = "https://nixcon.org/";
 }


### PR DESCRIPTION
## Description

Currently the nixcon link goes to https://2023.nixcon.org/

It seems like if you go to https://nixcon.org/ you to redirected to the latest year
