### PR TITLE
Update NUG Poland URL

### DIFF
--- a/lists/NUGs/poland/default.nix
+++ b/lists/NUGs/poland/default.nix
@@ -4,5 +4,5 @@
   subtitle =  "No strict schedule";
   tag = "Poland";
   target = "_blank";
-  url = "https://discord.gg/eJnKKjQ3Bc";
+  url = "https://poland.nix.ug";
 }


### PR DESCRIPTION
We now have an official (albeit barebones) landing page, with links to both our Discord and Matrix servers. Use that instead of the direct Discord link :)